### PR TITLE
feat(talos): bump talosVersion to v1.14.0

### DIFF
--- a/talos/patches/controller/cluster.yaml
+++ b/talos/patches/controller/cluster.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.13.0/pkg/machinery/config/schemas/config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.14.0/pkg/machinery/config/schemas/config.schema.json
 cluster:
   allowSchedulingOnControlPlanes: true
   apiServer:

--- a/talos/patches/controller/machine-features.yaml
+++ b/talos/patches/controller/machine-features.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.13.0/pkg/machinery/config/schemas/config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.14.0/pkg/machinery/config/schemas/config.schema.json
 machine:
   features:
     hostDNS:

--- a/talos/patches/global/machine-files.yaml
+++ b/talos/patches/global/machine-files.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.13.0/pkg/machinery/config/schemas/config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.14.0/pkg/machinery/config/schemas/config.schema.json
 machine:
   files:
     - op: create

--- a/talos/patches/global/machine-kubelet.yaml
+++ b/talos/patches/global/machine-kubelet.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.13.0/pkg/machinery/config/schemas/config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.14.0/pkg/machinery/config/schemas/config.schema.json
 machine:
   kubelet:
     defaultRuntimeSeccompProfileEnabled: true

--- a/talos/patches/global/machine-network.yaml
+++ b/talos/patches/global/machine-network.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.13.0/pkg/machinery/config/schemas/config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.14.0/pkg/machinery/config/schemas/config.schema.json
 apiVersion: v1alpha1
 kind: ResolverConfig
 nameservers:

--- a/talos/patches/global/machine-nut.yaml
+++ b/talos/patches/global/machine-nut.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.13.0/pkg/machinery/config/schemas/config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.14.0/pkg/machinery/config/schemas/config.schema.json
 apiVersion: v1alpha1
 kind: ExtensionServiceConfig
 name: nut-client

--- a/talos/patches/global/machine-storage.yaml
+++ b/talos/patches/global/machine-storage.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.13.0/pkg/machinery/config/schemas/config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.14.0/pkg/machinery/config/schemas/config.schema.json
 apiVersion: v1alpha1
 kind: UserVolumeConfig
 name: local-hostpath

--- a/talos/patches/global/machine-sysctls.yaml
+++ b/talos/patches/global/machine-sysctls.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.13.0/pkg/machinery/config/schemas/config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.14.0/pkg/machinery/config/schemas/config.schema.json
 machine:
   sysctls:
     fs.inotify.max_user_watches: "1048576"     # Watchdog

--- a/talos/patches/global/talos-03-kubelet.yaml
+++ b/talos/patches/global/talos-03-kubelet.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.13.0/pkg/machinery/config/schemas/config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.14.0/pkg/machinery/config/schemas/config.schema.json
 machine:
   kubelet:
     extraConfig:

--- a/talos/patches/storage/talos-01.yaml
+++ b/talos/patches/storage/talos-01.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.13.0/pkg/machinery/config/schemas/config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.14.0/pkg/machinery/config/schemas/config.schema.json
 apiVersion: v1alpha1
 kind: RawVolumeConfig
 name: miroir
@@ -8,7 +8,7 @@ provisioning:
     match: disk.serial == "S666NE0RB21047"
   minSize: 512GB
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.13.0/pkg/machinery/config/schemas/config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.14.0/pkg/machinery/config/schemas/config.schema.json
 apiVersion: v1alpha1
 kind: RawVolumeConfig
 name: miroir-local

--- a/talos/patches/storage/talos-02.yaml
+++ b/talos/patches/storage/talos-02.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.13.0/pkg/machinery/config/schemas/config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.14.0/pkg/machinery/config/schemas/config.schema.json
 apiVersion: v1alpha1
 kind: RawVolumeConfig
 name: miroir
@@ -8,7 +8,7 @@ provisioning:
     match: disk.serial == "S436NA0NA10141"
   minSize: 512GB
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.13.0/pkg/machinery/config/schemas/config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.14.0/pkg/machinery/config/schemas/config.schema.json
 apiVersion: v1alpha1
 kind: RawVolumeConfig
 name: miroir-local

--- a/talos/patches/storage/talos-03.yaml
+++ b/talos/patches/storage/talos-03.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.13.0/pkg/machinery/config/schemas/config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/v1.14.0/pkg/machinery/config/schemas/config.schema.json
 apiVersion: v1alpha1
 kind: RawVolumeConfig
 name: miroir

--- a/talos/talenv.yaml
+++ b/talos/talenv.yaml
@@ -1,4 +1,4 @@
 # renovate: datasource=custom.talos-factory depName=siderolabs/talos
-talosVersion: v1.13.7
+talosVersion: v1.14.0
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
 kubernetesVersion: v1.36.3


### PR DESCRIPTION
# Talos 1.13.7 -> 1.14.0 migration

## Changes made
- `talos/talenv.yaml`: `talosVersion` bumped `v1.13.7` -> `v1.14.0`
- All `talos/patches/**` schema-URL comments bumped `v1.13.0` -> `v1.14.0` (cosmetic, editor lint only)

`kubernetesVersion` left at `v1.36.3` (renovate-tracked separately). Talos 1.14.0 bundles/supports Kubernetes 1.37.0 but 1.36.x is still within the supported skew — no forced k8s bump needed for this migration.

## Breaking changes checked against this cluster

- **sandboxd / workload isolation, iSCSI in-tree plugin removed**: not used. Storage here is ZFS/DRBD/local-hostpath/raw-volumes via `UserVolumeConfig`/`RawVolumeConfig`, no Longhorn, no in-tree iSCSI CSI. Safe.
- **`noexec` on `/var` by default**: only applies to *new* clusters; existing clusters keep prior behavior on upgrade. No Longhorn v1 in use anyway. No action needed.
- **`talosctl apply-config --mode=reboot` removed**: `.taskfiles/talos/Taskfile.yaml` `apply-node` task defaults to `--mode=auto`, doesn't use `reboot`. Unaffected.
- **etcd metrics moved to port 2383 by default**: `talos/patches/controller/cluster.yaml` already pins a custom `listen-metrics-urls: http://0.0.0.0:2381`. Unaffected.
- **TLS min version raised to 1.3 for etcd/kube-apiserver**: no custom TLS config in this repo overriding that. No action needed, just be aware for any external etcd/apiserver clients that only speak TLS 1.2.
- **Support bundles encrypted by default (age)**: only affects `talosctl support` output, no repo changes needed.

## Optional (not required, not applied) 1.14 features worth a follow-up

- `SecurityProfileConfig` to opt in to `sandboxd` workload isolation on this cluster.
- `FilesystemTrimConfig` for periodic trim (disabled by default on upgraded, non-new clusters).
- Native BGP (`GoBGP`) if ever moving off static VIP/bonding for routing.
- Declarative RAID (`RAIDArrayConfig`) / LVM (`LVMVolumeGroupConfig`) — not relevant, cluster uses ZFS + raw disks.

`ResolverConfig` (DoT/DoH-capable) is already in use (`talos/patches/global/machine-network.yaml`), so no change needed there either.

## Upgrade procedure

All 3 nodes are control-plane (`allowSchedulingOnControlPlanes: true`), upgrade one at a time and let etcd/health checks settle between nodes:

```
task talos:upgrade-node IP=192.168.10.10
task talos:upgrade-node IP=192.168.10.11
task talos:upgrade-node IP=192.168.10.12
```

Then regenerate configs from the bumped `talenv.yaml`/schema comments and push:

```
task talos:generate-config
task talos:apply-node IP=192.168.10.10
task talos:apply-node IP=192.168.10.11
task talos:apply-node IP=192.168.10.12
```

Verify after each node: `talosctl health`, `kubectl get nodes`.
